### PR TITLE
fix: handle pg timestamp faker truncation

### DIFF
--- a/src/main/ipc-handlers/tables.ts
+++ b/src/main/ipc-handlers/tables.ts
@@ -400,7 +400,8 @@ export default (connections: Record<string, antares.Client>) => {
                      fakeValue = (fakerCustom as any)[params.row[key].group][params.row[key].method]();
 
                   if (typeof fakeValue === 'string') {
-                     if (params.row[key].length)
+                     // Only trim textual values by declared length; datetime length is precision.
+                     if (params.row[key].length && [...TEXT, ...LONG_TEXT].includes(type))
                         fakeValue = fakeValue.substring(0, params.row[key].length);
 
                      switch (connections[params.uid]._client) {


### PR DESCRIPTION
Fix #1 
PostgreSQL TIMESTAMPTZ 列中，timestamp(6)中的6表示精度，而非字符串限制长度。
原有代码按6进行截断，将'2026-03-02...' 截断为'2026-0'。
现在仅对TEXT进行截断。