### PR TITLE
Fix Pgsql contains $ symbol sql error

### DIFF
--- a/src/common/libs/sqlUtils.ts
+++ b/src/common/libs/sqlUtils.ts
@@ -62,6 +62,7 @@ export const querySplitter =(sql: string, dbType: ClientCode): string[] => {
             const match = line.slice(i).match(dollarTagRegex);
             if (match) {
                const tag = match[0];
+               currentQuery += tag.slice(1);
                if (!insideDollarTag) {
                   insideDollarTag = true;
                   dollarTagDelimiter = tag;


### PR DESCRIPTION
Fix #3 
原代码对PostgreSQL中的$$解析验证不完善，且存在字符追加Bug，新版本进行修复。

✅下面代码已正确解析：
```sql
SELECT '$abc$';
SELECT '$$$';
SELECT '$abc$def$';
SELECT '$$test$$';

SELECT $$hello$$;
SELECT $$hello; world$$;

SELECT $tag$hello$tag$;
SELECT $abc$hello;world$abc$;

CREATE FUNCTION test()
RETURNS void AS $func$
BEGIN
RAISE NOTICE '$100';
END;
$func$ LANGUAGE plpgsql;
```